### PR TITLE
Add framework to customize MarkdigEngine

### DIFF
--- a/MarkdigEngine.Plugin/IMarkdigCustomizer.cs
+++ b/MarkdigEngine.Plugin/IMarkdigCustomizer.cs
@@ -1,0 +1,14 @@
+﻿using Markdig;
+
+namespace MarkdigEngine.Plugin
+{
+    public interface IMarkdigCustomizer
+    {
+        /// <summary>
+        /// Customize the <see cref="MarkdownPipelineBuilder">
+        /// </summary>
+        /// <param name="builder">The original pipeline builder from MarkdigEngine</param>
+        /// <returns>The customized pipline builder</returns>
+        MarkdownPipelineBuilder Customize(MarkdownPipelineBuilder builder);
+    }
+}

--- a/MarkdigEngine/MarkdigMarkdownService.cs
+++ b/MarkdigEngine/MarkdigMarkdownService.cs
@@ -1,4 +1,7 @@
-﻿using System.Collections.Immutable;
+﻿using System.Collections.Generic;
+using System.Collections.Immutable;
+
+using MarkdigEngine.Plugin;
 
 using Microsoft.DocAsCode.Plugins;
 
@@ -8,13 +11,16 @@ namespace MarkdigEngine
     {
         private readonly MarkdownServiceParameters _parameters;
         private readonly MarkdownValidatorBuilder _mvb;
+        private readonly ImmutableArray<IMarkdigCustomizer> _markdigCustomizers;
 
         public MarkdigMarkdownService(
             MarkdownServiceParameters parameters,
-            ICompositionContainer container = null)
+            ICompositionContainer container,
+            IEnumerable<IMarkdigCustomizer> markdigCustomizers)
         {
             _parameters = parameters;
             _mvb = MarkdownValidatorBuilder.Create(parameters, container);
+            _markdigCustomizers = markdigCustomizers.ToImmutableArray();
         }
 
         public MarkupResult Markup(string content, string path)

--- a/MarkdigEngine/MarkdigMarked.cs
+++ b/MarkdigEngine/MarkdigMarked.cs
@@ -50,6 +50,11 @@ namespace MarkdigEngine
                 pipeline.UseInineParserOnly();
             }
 
+            foreach(var customizer in context.MarkdigCustomizers)
+            {
+                pipeline = customizer.Customize(pipeline);
+            }
+
             return pipeline.Build();
         }
 

--- a/MarkdigEngine/MarkdigServiceProvider.cs
+++ b/MarkdigEngine/MarkdigServiceProvider.cs
@@ -1,18 +1,25 @@
 ﻿using System.Composition;
 
 using Microsoft.DocAsCode.Plugins;
+using System.Collections.Generic;
+using System.Linq;
+
+using MarkdigEngine.Plugin;
 
 namespace MarkdigEngine
 {
     [Export("markdig", typeof(IMarkdownServiceProvider))]
     public class MarkdigServiceProvider : IMarkdownServiceProvider
     {
+        [ImportMany]
+        public IEnumerable<IMarkdigCustomizer> MarkdigCustomizers { get; set; } = Enumerable.Empty<IMarkdigCustomizer>();
+
         [Import]
         public ICompositionContainer Container { get; set; }
 
         public IMarkdownService CreateMarkdownService(MarkdownServiceParameters parameters)
         {
-            return new MarkdigMarkdownService(parameters, Container);
+            return new MarkdigMarkdownService(parameters, Container, MarkdigCustomizers);
         }
     }
 }

--- a/MarkdigEngine/MarkdownContext.cs
+++ b/MarkdigEngine/MarkdownContext.cs
@@ -1,6 +1,8 @@
 ﻿using System.Collections.Generic;
 using System.Collections.Immutable;
 
+using MarkdigEngine.Plugin;
+
 namespace MarkdigEngine
 {
     public class MarkdownContext
@@ -25,6 +27,8 @@ namespace MarkdigEngine
         public List<string> Dependency { get; private set; }
 
         public MarkdownValidatorBuilder Mvb { get; }
+
+        public ImmutableArray<IMarkdigCustomizer> MarkdigCustomizers { get; }
 
         public MarkdownContext(string filePath,
             string basePath,


### PR DESCRIPTION
Need to support two scenarios:

1. Reuse original parser and customize corresponding renderer.
2. Customize both parser and renderer.
